### PR TITLE
Fix: set AppBaselines-BCArtifacts to 29.0.48710.0

### DIFF
--- a/Build/Packages.json
+++ b/Build/Packages.json
@@ -4,7 +4,7 @@
     "Source": "NuGet.org"
   },
   "AppBaselines-BCArtifacts": {
-    "Version": "29.0.48710",
+    "Version": "29.0.48710.0",
     "Source": "BCArtifacts",
     "_comment": "Used to fetch app baselines from BC artifacts"
   }


### PR DESCRIPTION
Follow-up CI fix.

The latest run still failed during baseline restore with:
- Unable to find URL for baseline version 29.0.48710

This change updates Build/Packages.json to use a full 4-segment BC artifact version:
- AppBaselines-BCArtifacts.Version: 29.0.48710 -> 29.0.48710.0

This aligns with the expected artifact version format used by baseline restore and should resolve URL lookup.