### PR TITLE
Fix: fallback baseline artifact version when pinned version is unavailable

### DIFF
--- a/Build/Scripts/GuardingV2ExtensionsHelper.psm1
+++ b/Build/Scripts/GuardingV2ExtensionsHelper.psm1
@@ -92,6 +92,8 @@ function Restore-BaselinesFromArtifacts {
     )
     Import-Module -Name $PSScriptRoot\EnlistmentHelperFunctions.psm1
 
+    $originalBaselineVersion = $BaselineVersion
+
     if (-not $BaselineVersion) {
         $baselinePackage = Get-ConfigValue -Key "AppBaselines-BCArtifacts" -ConfigType Packages
         if (-not $baselinePackage) {
@@ -113,6 +115,36 @@ function Restore-BaselinesFromArtifacts {
         }
 
         if (-not $baselineURL) {
+            Write-Host "::Warning:: Unable to find URL for baseline version $BaselineVersion"
+            Write-Host "Trying latest compatible AppBaselines-BCArtifacts version..."
+
+            $fallbackBaselineVersion = $null
+            try {
+                $fallbackBaselineVersion = Get-PackageLatestVersion -PackageName "AppBaselines-BCArtifacts"
+            }
+            catch {
+                Write-Host "::Warning:: Could not resolve fallback baseline version: $($_.Exception.Message)"
+            }
+
+            if ($fallbackBaselineVersion -and ($fallbackBaselineVersion -ne $BaselineVersion)) {
+                $BaselineVersion = $fallbackBaselineVersion
+                $baselineFolder = Join-Path (Get-BaseFolder) "out/baselineartifacts/$BaselineVersion"
+
+                if (-not (Test-Path $baselineFolder)) {
+                    $baselineURL = Get-BCArtifactUrl -type Sandbox -country W1 -version $BaselineVersion
+
+                    if (-not $baselineURL) {
+                        #Fallback to bcinsider
+                        $baselineURL = Get-BCArtifactUrl -type Sandbox -country W1 -version $BaselineVersion -storageAccount bcinsider -accept_insiderEula
+                    }
+                }
+            }
+        }
+
+        if (-not $baselineURL) {
+            if ($originalBaselineVersion) {
+                throw "Unable to find URL for baseline versions $originalBaselineVersion or $BaselineVersion"
+            }
             throw "Unable to find URL for baseline version $BaselineVersion"
         }
         Write-Host "Downloading from $baselineURL to $baselineFolder"


### PR DESCRIPTION
This fixes repeated CI/CD failures during breaking changes baseline restore.

Problem:
- Build fails with: Unable to find URL for baseline version <pinned version>
- Pinned baseline versions in Build/Packages.json can become unavailable in BC artifacts.

Change:
- Updated Build/Scripts/GuardingV2ExtensionsHelper.psm1 (Restore-BaselinesFromArtifacts):
  - If URL lookup fails for the configured BaselineVersion, it now tries a fallback.
  - Fallback uses Get-PackageLatestVersion('AppBaselines-BCArtifacts') to resolve latest compatible artifact version.
  - It then retries URL resolution and artifact download using that fallback version.
  - Improved error message to show both attempted versions when both fail.

Result:
- Pipeline is resilient to unavailable pinned baseline artifact builds while keeping breaking-changes checks enabled.